### PR TITLE
Maybe add some markdown-manipulation tasks

### DIFF
--- a/Scripts/Tools/TrimMarkdown.gd
+++ b/Scripts/Tools/TrimMarkdown.gd
@@ -1,0 +1,56 @@
+extends "res://Scripts/Tools/ScriptTask.gd"
+
+func _init() -> void:
+	add_expected_argument("input", "Original markdown file to trim.")
+	add_expected_argument("output", "Path to save trimmed file to.")
+	add_expected_argument("header", "Header to trim file to.")
+
+	if not fetch_arguments():
+		return
+
+	var input_path: String = arguments["input"]
+	var output_path: String = arguments["output"]
+	var header: String = arguments["header"]
+
+	var error: int = OK
+	error = trim_file(input_path, output_path, header)
+	quit(error)
+
+func trim_file(input_path: String, output_path: String, header: String) -> int:
+	var input_file := FileAccess.open(input_path, FileAccess.READ)
+	var output_file := FileAccess.open(output_path, FileAccess.WRITE)
+
+	var writing := false
+	while input_file.get_position() < input_file.get_length():
+		var line = input_file.get_line()
+		if not writing:
+			if line.begins_with(header):
+				writing = true
+				output_file.store_line(line)
+		else:
+			var header_number = get_header_number(line)
+			if header_number > 0 and header_number <= get_header_number(header):
+				break
+			output_file.store_line(line)
+
+	input_file.close()
+	output_file.close()
+
+	if input_file.get_error() != OK:
+		return input_file.get_error()
+	return output_file.get_error()
+
+func get_header_number(line: String) -> int:
+	if line.begins_with("# "):
+		return 1
+	elif line.begins_with("## "):
+		return 2
+	elif line.begins_with("### "):
+		return 3
+	elif line.begins_with("#### "):
+		return 4
+	elif line.begins_with("##### "):
+		return 5
+	elif line.begins_with("###### "):
+		return 6
+	return 0

--- a/Tasks/PandocMDtoHTML.tscn
+++ b/Tasks/PandocMDtoHTML.tscn
@@ -1,0 +1,115 @@
+[gd_scene load_steps=3 format=3 uid="uid://doc6awd7du3ku"]
+
+[ext_resource type="PackedScene" uid="uid://cyl1d6reu3mk4" path="res://Nodes/GUI/DirectorySelector.tscn" id="2_8177b"]
+
+[sub_resource type="GDScript" id="GDScript_dhanr"]
+script/source = "extends Task
+
+@onready var source_path: Control = %SourcePath
+@onready var target_path: Control = %TargetPath
+
+func _get_task_name() -> String:
+	return \"Convert .md to .html\"
+
+func _get_task_info() -> PackedStringArray:
+	return [
+		\"Converts the given .md file to a .html file at a new location.\",
+		\"Source Path|Markdown file which is going to be converted.\",
+		\"Target Path|Path and name to convert to.\",
+	]
+
+func _get_execute_string() -> String:
+	return \"Convert %s to %s\" % [source_path.text, target_path.text]
+
+static func _initialize_project() -> void:
+	pass
+
+static func _begin_project_scan() -> void:
+	pass
+
+static func _process_file(path: String) -> void:
+	pass
+
+static func _end_project_scan() -> void:
+	pass
+
+func _initialize() -> void:
+	defaults[\"source_path\"] = \"\"
+	defaults[\"target_path\"] = \"\"
+
+func _prevalidate() -> bool:
+	if source_path.text == target_path.text:
+		error_message = \"Source and target paths are the same.\"
+		return false
+	else:
+		return true
+
+func _validate() -> bool:
+	if not FileAccess.file_exists(Data.resolve_path(source_path.text)):
+		error_message = \"Source path does not point to a file.\"
+
+	return error_message.is_empty()
+
+func _get_command() -> String:
+	return \"pandoc\"
+
+func _get_arguments() -> PackedStringArray:
+	var ret: PackedStringArray
+
+	ret.append(\"-o\")
+	ret.append(Data.resolve_path(target_path.text))
+	ret.append(Data.resolve_path(source_path.text))
+
+	return ret
+
+func _prepare() -> void:
+	pass
+
+func _cleanup() -> void:
+	pass
+
+func _load() -> void:
+	source_path.text = data[\"source_path\"]
+	target_path.text = data[\"target_path\"]
+
+func _store() -> void:
+	data[\"source_path\"] = source_path.text
+	data[\"target_path\"] = target_path.text
+"
+
+[node name="PandocMDtoHtml" type="GridContainer"]
+custom_minimum_size = Vector2(400, 0)
+offset_right = 400.0
+offset_bottom = 66.0
+columns = 2
+script = SubResource("GDScript_dhanr")
+
+[node name="Label" type="Label" parent="."]
+custom_minimum_size = Vector2(150, 0)
+layout_mode = 2
+size_flags_horizontal = 8
+text = ".md Source Path"
+horizontal_alignment = 2
+
+[node name="SourcePath" parent="." instance=ExtResource("2_8177b")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+mode = 3
+scope = 1
+missing_mode = 1
+
+[node name="Label2" type="Label" parent="."]
+auto_translate_mode = 1
+layout_mode = 2
+size_flags_horizontal = 8
+text = ".html Target Path"
+horizontal_alignment = 2
+
+[node name="TargetPath" parent="." instance=ExtResource("2_8177b")]
+unique_name_in_owner = true
+auto_translate_mode = 1
+layout_mode = 2
+size_flags_horizontal = 3
+mode = 2
+scope = 1

--- a/Tasks/TrimMarkdown.tscn
+++ b/Tasks/TrimMarkdown.tscn
@@ -1,0 +1,137 @@
+[gd_scene load_steps=3 format=3 uid="uid://rboobukjipe7"]
+
+[ext_resource type="PackedScene" uid="uid://cyl1d6reu3mk4" path="res://Nodes/GUI/DirectorySelector.tscn" id="1_daj5t"]
+
+[sub_resource type="GDScript" id="GDScript_dhanr"]
+script/source = "extends \"res://Tasks/ScriptTask.gd\"
+
+@onready var input_path: Control = %InputPath
+@onready var output_path: Control = %OutputPath
+@onready var header: LineEdit = %Header
+
+func _get_task_name() -> String:
+	return \"Trim MD File\"
+
+func _get_task_info() -> PackedStringArray:
+	return [
+		\"Trims the given .md file to include only the given header.\",
+		\"Input Path|Original markdown file.\",
+		\"Output Path|Trimmed markdown filepath.\",
+		\"Header|Header to trim it to, excluding everything else. The trimmed file will include only text and subheaders under the first header that begins with this string.\",
+	]
+
+func _get_execute_string() -> String:
+	return \"Trim markdown file at %s to %s, including only %s\" % [input_path.text, output_path.text, header.text]
+
+static func _initialize_project() -> void:
+	pass
+
+static func _begin_project_scan() -> void:
+	pass
+
+static func _process_file(path: String) -> void:
+	pass
+
+static func _end_project_scan() -> void:
+	pass
+
+func _initialize() -> void:
+	defaults[\"input_path\"] = \"\"
+	defaults[\"output_path\"] = \"\"
+	defaults[\"header\"] = \"\"
+
+func _prevalidate() -> bool:
+	if input_path.text.is_empty():
+		error_message = \"No input path given.\"
+	elif output_path.text.is_empty():
+		error_message = \"No output path given.\"
+	elif header.text.is_empty():
+		error_message = \"No header given.\"
+	elif not header.text.begins_with(\"#\"):
+		error_message = \"Invalid markdown header.\"
+
+	return error_message.is_empty()
+
+func _validate() -> bool:
+	if not FileAccess.file_exists(Data.resolve_path(input_path.text)):
+		error_message = \"Input path does not point to a file.\"
+
+	return error_message.is_empty()
+
+func _get_arguments() -> PackedStringArray:
+	var ret := super()
+
+	ret.append(Data.resolve_path(input_path.text))
+	ret.append(Data.resolve_path(output_path.text))
+	ret.append(header.text)
+
+	return ret
+
+func _prepare() -> void:
+	pass
+
+func _cleanup() -> void:
+	pass
+
+func _load() -> void:
+	input_path.text = data[\"input_path\"]
+	output_path.text = data[\"output_path\"]
+	header.text = data[\"header\"]
+
+func _store() -> void:
+	data[\"input_path\"] = input_path.text
+	data[\"output_path\"] = output_path.text
+	data[\"header\"] = header.text
+"
+
+[node name="TrimMarkdown" type="GridContainer"]
+custom_minimum_size = Vector2(400, 0)
+offset_right = 400.0
+offset_bottom = 66.0
+columns = 2
+script = SubResource("GDScript_dhanr")
+script_name = "TrimMarkdown.gd"
+
+[node name="Label" type="Label" parent="."]
+custom_minimum_size = Vector2(150, 0)
+layout_mode = 2
+size_flags_horizontal = 8
+text = "Input Path"
+horizontal_alignment = 2
+
+[node name="InputPath" parent="." instance=ExtResource("1_daj5t")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+mode = 1
+scope = 1
+missing_mode = 1
+filters = PackedStringArray("*.md")
+
+[node name="Label2" type="Label" parent="."]
+custom_minimum_size = Vector2(150, 0)
+layout_mode = 2
+size_flags_horizontal = 8
+text = "Output Path"
+horizontal_alignment = 2
+
+[node name="OutputPath" parent="." instance=ExtResource("1_daj5t")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+mode = 2
+scope = 1
+filters = PackedStringArray("*.md")
+
+[node name="Label3" type="Label" parent="."]
+auto_translate_mode = 1
+layout_mode = 2
+size_flags_horizontal = 8
+text = "Header"
+horizontal_alignment = 2
+
+[node name="Header" type="LineEdit" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+placeholder_text = "## Header to include"


### PR DESCRIPTION
I made a few tasks for my own use. Maybe you would like to package them together with the others. Before I clean them up I should ask you what your thinking is for adding more tasks. Would you want to add these tasks? Should they be changed in a significant way before being added?


### PandocMDtoHTML

This task uses [Pandoc](https://pandoc.org/) to make a simple conversion from markdown to HTML. I use this to package a changelog with the game in a format players are more likely to understand.

It requires Pandoc to be installed. Perhaps a better implementation would be to have a wrapper for more of Pandoc's functionality instead of just this one conversion. It's also questionable if this needs to be its own task since it can be implemented as a one-line command: `pandoc -o target.html source.md`. But having this task is slightly more convenient.


### TrimMarkdown

This task trims a markdown file to include only the specified header. I use this in an automation pipeline to push only the most recent changelog information onto a Releases page.

Since this uses a script it can't be used by adding to the Tasks folder of a prebuilt Project Builder executable. I think a better implementation would be to specify the starting and ending line of the trimmed file and let it work on all text files. Then to include only everything under the first `##` header of a markdown file I could set the options:

* Start: `##`
* Include: `true`
* End: `##`
* Include: `false`

