### PR TITLE
Add cli parameter for loading different projects file

### DIFF
--- a/Nodes/GUI/DirectorySelector.tscn
+++ b/Nodes/GUI/DirectorySelector.tscn
@@ -27,7 +27,7 @@ var text: String:
 		return line_edit.text
 
 func _ready() -> void:
-	#line_edit.text_submitted.connect(path_changed.emit.unbind(1).call(new_text))
+	line_edit.text_submitted.connect(path_changed.emit.unbind(1))
 	match mode:
 		Mode.SELECT_FOLDER, Mode.FAKE_SELECT_FOLDER:
 			file_dialog.file_mode = FileDialog.FILE_MODE_OPEN_DIR
@@ -55,7 +55,7 @@ func _path_selected(path: String) -> void:
 	else:
 		text = path
 	
-	path_changed.emit()
+	path_changed.emit(\"\")
 
 func validate():
 	if missing_mode == MissingMode.IGNORE:

--- a/Nodes/GUI/DirectorySelector.tscn
+++ b/Nodes/GUI/DirectorySelector.tscn
@@ -27,7 +27,7 @@ var text: String:
 		return line_edit.text
 
 func _ready() -> void:
-	line_edit.text_changed.connect(path_changed.emit.unbind(1))
+	#line_edit.text_submitted.connect(path_changed.emit.unbind(1).call(new_text))
 	match mode:
 		Mode.SELECT_FOLDER, Mode.FAKE_SELECT_FOLDER:
 			file_dialog.file_mode = FileDialog.FILE_MODE_OPEN_DIR
@@ -90,6 +90,7 @@ func validate():
 offset_right = 256.0
 offset_bottom = 31.0
 script = SubResource("GDScript_af0jw")
+missing_mode = 1
 
 [node name="LineEdit" type="LineEdit" parent="."]
 layout_mode = 2

--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ godot --path "C:/Project Builder" -- --open-project "C:/My Project" --execute_ro
 ```
 The `--path` part can be omitted when running from Project Builder installation directory.
 
+## Start with different projects.cfg (Project list)
+For the case of using the self-contained mode of the Engine.
+For example you will test new develope or release-candidate versions
+
+See docpage: https://docs.godotengine.org/en/4.3/tutorials/io/data_paths.html#self-contained-mode
+
+you can start with the parameter `--projects-file-path [PathToEngine]\editor_date\projects.cfg` or `--projects-file-path [PathToEngine]\editor_date\` (only directory path with ending backslash)
 
 ## List of Available Tasks
 

--- a/Scenes/ProjectManager.gd
+++ b/Scenes/ProjectManager.gd
@@ -52,7 +52,8 @@ func _ready() -> void:
 	# check if file does exists
 	if !FileAccess.file_exists(editor_data):
 		printerr("projects-file -- File not found: %s" % editor_data)
-		get_tree().quit(1)
+		OS.alert("File not found: %s" % editor_data, 'projects.cfg not found')
+		#get_tree().quit(1)
 		return
 		
 	var project_list := ConfigFile.new()

--- a/Scenes/ProjectManager.gd
+++ b/Scenes/ProjectManager.gd
@@ -58,7 +58,7 @@ func _ready() -> void:
 	
 	# check if file does exists
 	if !FileAccess.file_exists(editor_data):
-		printerr("--projects-file-path -- File not found")
+		printerr("projects-file -- File not found: %s" % editor_data)
 		get_tree().quit(1)
 		return
 		

--- a/Scenes/ProjectManager.gd
+++ b/Scenes/ProjectManager.gd
@@ -2,7 +2,12 @@ extends Control
 
 var user_arguments := OS.get_cmdline_user_args()
 
+@onready var directory_selector: HBoxContainer = $VBoxContainer2/HBoxContainer/DirectorySelector
+
+
 func _ready() -> void:
+	directory_selector.path_changed.connect(_on_custom_projects_changed)
+	
 	var i := user_arguments.find("--open-project")
 	if i > -1:
 		if user_arguments.size() < i + 2:
@@ -62,7 +67,7 @@ func _ready() -> void:
 	
 	for project in project_list.get_sections():
 		var project_entry := preload("res://Nodes/ProjectEntry.tscn").instantiate()
-		$VBoxContainer.add_child(project_entry)
+		$VBoxContainer2/VBoxContainer.add_child(project_entry)
 		project_entry.set_project(project, load_project)
 
 func load_project(project: String):

--- a/Scenes/ProjectManager.gd
+++ b/Scenes/ProjectManager.gd
@@ -7,6 +7,7 @@ var user_arguments := OS.get_cmdline_user_args()
 
 func _ready() -> void:
 	directory_selector.line_edit.text_submitted.connect(_on_custom_projects_submitted)
+	directory_selector.path_changed.connect(_on_custom_projects_submitted)
 	
 	var i := user_arguments.find("--open-project")
 	if i > -1:

--- a/Scenes/ProjectManager.gd
+++ b/Scenes/ProjectManager.gd
@@ -26,9 +26,39 @@ func _ready() -> void:
 	if i > -1:
 		printerr("--exit argument provided, but no --execute-routine. It will be ignored.")
 	
-	var editor_data := OS.get_user_data_dir().get_base_dir().get_base_dir()
+	
+	#region CLI --projects-file-path
+	## if using different Engine Version with the ._sc_ file
+	## https://docs.godotengine.org/en/4.3/tutorials/io/data_paths.html#self-contained-mode
+	var editor_data : String
+	i = user_arguments.find("--projects-file-path")
+	if i > -1:
+		if user_arguments.size() < i + 2:
+			printerr("--projects-file-path -- The projects file / path is not provided")
+		else:
+			var project_file_path := user_arguments[i + 1]
+			#region Parameter check
+			#check for valid filepath
+			if !project_file_path.get_file().is_empty():
+				editor_data = project_file_path
+			elif DirAccess.dir_exists_absolute(project_file_path): # if not a file, then check directory exists
+				editor_data = project_file_path.path_join("projects.cfg")
+			else:	# Fallback to default userdatadir
+				editor_data = OS.get_user_data_dir().get_base_dir().get_base_dir().path_join("projects.cfg")
+			#endregion
+	else:
+		# Fallback to default datadir
+		editor_data = OS.get_user_data_dir().get_base_dir().get_base_dir().path_join("projects.cfg")
+	#endregion
+	
+	# check if file does exists
+	if !FileAccess.file_exists(editor_data):
+		printerr("--projects-file-path -- File not found")
+		get_tree().quit(1)
+		return
+		
 	var project_list := ConfigFile.new()
-	project_list.load(editor_data.path_join("projects.cfg"))
+	project_list.load(editor_data)
 	
 	for project in project_list.get_sections():
 		var project_entry := preload("res://Nodes/ProjectEntry.tscn").instantiate()

--- a/Scenes/ProjectManager.gd
+++ b/Scenes/ProjectManager.gd
@@ -6,7 +6,7 @@ var user_arguments := OS.get_cmdline_user_args()
 
 
 func _ready() -> void:
-	directory_selector.path_changed.connect(_on_custom_projects_changed)
+	directory_selector.line_edit.text_submitted.connect(_on_custom_projects_submitted)
 	
 	var i := user_arguments.find("--open-project")
 	if i > -1:
@@ -103,7 +103,7 @@ func print_routines_and_exit():
 	if Data.auto_exit:
 		get_tree().quit(1)
 
-func _on_custom_projects_changed() -> void: 
+func _on_custom_projects_submitted(_text) -> void: 
 	print("_on_custom_projects_changed()")
 	#clear list
 	clear_project_list()

--- a/Scenes/ProjectManager.tscn
+++ b/Scenes/ProjectManager.tscn
@@ -28,8 +28,9 @@ text = "Custom project.cfg"
 [node name="DirectorySelector" parent="VBoxContainer2/HBoxContainer" instance=ExtResource("2_8a1pu")]
 custom_minimum_size = Vector2(250, 0)
 layout_mode = 2
-mode = 1
+mode = 3
 missing_mode = 2
+filters = PackedStringArray("*.cfg")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer2"]
 layout_mode = 2

--- a/Scenes/ProjectManager.tscn
+++ b/Scenes/ProjectManager.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://eu3eioilmxkb"]
+[gd_scene load_steps=3 format=3 uid="uid://eu3eioilmxkb"]
 
 [ext_resource type="Script" path="res://Scenes/ProjectManager.gd" id="1_edpqn"]
+[ext_resource type="PackedScene" uid="uid://cyl1d6reu3mk4" path="res://Nodes/GUI/DirectorySelector.tscn" id="2_8a1pu"]
 
 [node name="ProjectManager" type="ScrollContainer"]
 anchors_preset = 15
@@ -11,7 +12,26 @@ grow_vertical = 2
 script = ExtResource("1_edpqn")
 metadata/_edit_lock_ = true
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="VBoxContainer2" type="VBoxContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer2"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Label" type="Label" parent="VBoxContainer2/HBoxContainer"]
+layout_mode = 2
+text = "Custom project.cfg"
+
+[node name="DirectorySelector" parent="VBoxContainer2/HBoxContainer" instance=ExtResource("2_8a1pu")]
+custom_minimum_size = Vector2(250, 0)
+layout_mode = 2
+mode = 1
+missing_mode = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer2"]
 layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 3

--- a/cli_work_43_stable.cmd
+++ b/cli_work_43_stable.cmd
@@ -1,0 +1,138 @@
+@echo off
+chcp 65001
+
+cls
+
+:: #####
+:: Setting variables
+:: #####
+
+REM Full Project Path
+set "project=%~dp0"
+REM Path to Godot Executable
+set "gdpath=C:\Proggen\Godot\Godot_v4.3-stable"
+set "godotexe=Godot_v4.3-stable_win64.exe"
+set "godotver=Godot_v4.3-stable_win64.exe --version"
+REM Full Engine Path
+set "build_godot=%gdpath%\%godotexe%"
+
+REM Profilename in export_presets.cfg
+REM set "build_profile=Windows Desktop"
+set "build_profile=Windows Desktop"
+REM export Type export-debug or export-release or export-pack (musst be .pck or .zip)
+set "build_type=export-debug"
+REM set "build_type=export-release"
+REM set "build_type=export-pack"
+
+REM Version sufffix for binary name
+set "build_version=master"
+REM Version sufffix for Engine Version
+set "build_gdversion="
+FOR /F %%I IN ('=%gdpath%\%godotver%') DO @SET "build_gdversion=%%I"
+
+set "build_project_name=GodotProjectBuilder"
+REM Path to Export root folder
+set "build_path=C:\Proggen\Godot\Projekte\export\%build_gdversion%\%build_project_name%"
+REM Subfolder for Export Profile, overwrites preset
+set "build_folder=%build_path%\%build_profile%"
+
+REM Output binary name
+set "build_bin=%build_project_name%_%build_version%_%build_gdversion%.exe"
+REM Full Build Path+Name
+set "build_project=%build_folder%\%build_bin%"
+REM Full Build Log output
+set "build_log=%build_folder%\export.log.txt"
+
+:: #####
+:: execute
+:: #####
+
+echo #####
+call :check_engine || echo check_engine Failed && exit /b -99
+echo #####
+
+call :check_folder || echo check_folder Failed && exit /b -99
+echo #####
+
+if exist "%build_project%" (
+    echo Existing Binary Exports will deleted first
+	del "%build_project%" /F
+)
+echo #####
+
+REM Godot 4.2.2 dont have the --log-file parameter
+REM --log-file "%build_log%"
+
+echo #####
+echo Execute Engine for import all resources
+"%build_godot%" --verbose --import --headless > "%build_log%" 2>&1
+echo #####
+
+
+echo Execute Build Process overwrite export_presets.cfg export path
+"%build_godot%" --verbose --headless  --%build_type% "%build_profile%" --path %project% "%build_project%" >> "%build_log%" 2>&1
+echo #####
+
+
+echo ERRORLEVEL: %ERRORLEVEL%
+if %ERRORLEVEL% EQU 0 (
+	call :check_export_output || echo Export Failed && exit /b -99
+)
+exit /b 0
+
+:: #####
+:: checks before execute project export
+:: #####
+:check_engine
+echo checking Engine Settings
+echo PATH: "%build_godot%"
+echo Version: "%build_gdversion%"
+
+if NOT exist "%build_godot%" (
+    echo path to engine or engine executabele does not exist
+	exit /b -1
+)
+
+exit /b 0
+
+:check_folder
+echo checking project and export Settings
+echo ProjectFile: "%project%project.godot"
+if NOT exist "%project%project.godot" (
+    echo the project file does not exist
+	exit /b -1
+)
+
+echo ExportFolder: "%build_folder%"
+if NOT exist "%build_folder%\." (
+    echo the build folder does not exist
+	echo creating ...
+	mkdir "%build_folder%"
+	::exit /b -1
+	call :check_folder || echo check_folder Failed && exit /b -99
+)
+
+exit /b 0
+
+:check_export_output
+echo checking export success
+echo Export Binary: %build_project%
+if NOT exist "%build_project%" (
+    echo the Exported Binary does not exist
+	exit /b -1
+)
+echo the export was successfull
+CHOICE /C XN /M "Start the exported binary [X] Execute or [N] do not" /N /D N /T 10
+IF %ERRORLEVEL% EQU 1 (
+    call "%build_project%"
+) else (
+    exit /b 0
+)
+exit /b 0
+:: #####
+
+
+REM "C:\Proggen\Godot\Godot_v4.2-stable\Godot_v4.2.2-stable_win64.exe" --verbose --headless 
+REM --log-file "C:\Proggen\Godot\Projekte\Just4Fun_Mini_Shootergame\export\gd-4-2-2_stable\Windows\export.log.txt" 
+REM --export-release "Windows" --path C:\Proggen\Godot\Projekte\Just4Fun_Mini_Shootergame\4.2.2-stable\\ 
+REM "C:\Proggen\Godot\Projekte\Just4Fun_Mini_Shootergame\export\gd-4-2-2_stable\Windows\MiniShooterGame_alpha7_4.2.2.stable.official.15073afe3.exe"


### PR DESCRIPTION

> New PR with Engine Version 4.3 stable
> For PR #21

Adding a new Parameter for CLI starting.

Reason: I use different Engine Versions, latest Stable and latest Dev / RC for example

I am using the self contained mode with the ._sc_file in the engine directory.
See Engine Documentation: https://docs.godotengine.org/en/4.3/tutorials/io/data_paths.html#self-contained-mode

With this addition it is possible to get different project list
--projects-file-path [PathToEngine]\editor_date\projects.cfg

Please ignore the .CMD File. It is my local export / Build script before i found your project. I have use it to build one exorted Version from your source. Because your last release is 4 month old.

I have added a short description to the readme.

I have commented the source for better understanding

First PR without Button for manually loading projects.cfg. It will follow.

