### PR TITLE
Enable execution to scroll automatically to the bottom

### DIFF
--- a/Scenes/Execution.gd
+++ b/Scenes/Execution.gd
@@ -1,4 +1,4 @@
-extends Control
+extends ScrollContainer
 
 signal finished
 
@@ -154,3 +154,6 @@ func _exit_tree() -> void:
 	
 	if task_in_progress:
 		current_task._cleanup()
+
+func _process(_delta: float) -> void:
+    scroll_vertical = get_v_scroll_bar().max_value


### PR DESCRIPTION
This PR uses _process to auto scroll the execution scene to the bottom to keep up with the output.

Sorry about the previous accidental PR, using GitHub in the web messed me up. I will setup soon to commit via git CLI ssh.

Please consider this as one of my first submissions for this project. I hope to make many more contributions as I can see a lot of value in this program.